### PR TITLE
Add static pages

### DIFF
--- a/app/component/PrivacyPolicyPage.js
+++ b/app/component/PrivacyPolicyPage.js
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import { Link } from 'react-router';
+import { FormattedMessage } from 'react-intl';
+import connectToStores from 'fluxible-addons-react/connectToStores';
+
+const PrivacyPolicyPagePage = ({ currentLanguage }, context) => {
+  const policy = context.config.privacyPolicy[currentLanguage];
+  return (
+    <div className="about-page fullscreen">
+      <div className="page-frame fullscreen momentum-scroll">
+        {policy.map(
+          (section, i) =>
+            (section.paragraphs && section.paragraphs.length) ||
+            section.link ? (
+              <div key={`about-section-${i}`}>
+                <h1 className="about-header">{section.header}</h1>
+                {section.paragraphs &&
+                  section.paragraphs.map((p, j) => (
+                    <p key={`about-section-${i}-p-${j}`}>{p}</p>
+                  ))}
+                {section.link && <Link to={section.link}>{section.link}</Link>}
+              </div>
+            ) : (
+              false
+            ),
+        )}
+        <Link to="/">
+          <div className="call-to-action-button">
+            <FormattedMessage
+              id="back-to-front-page"
+              defaultMessage="Back to front page"
+            />
+          </div>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+PrivacyPolicyPagePage.propTypes = {
+  currentLanguage: PropTypes.string.isRequired,
+};
+
+PrivacyPolicyPagePage.contextTypes = {
+  config: PropTypes.object.isRequired,
+};
+
+export default connectToStores(PrivacyPolicyPagePage, ['PreferencesStore'], context => ({
+  currentLanguage: context.getStore('PreferencesStore').getLanguage(),
+}));

--- a/app/component/TermsAndConditionsPage.js
+++ b/app/component/TermsAndConditionsPage.js
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import { Link } from 'react-router';
+import { FormattedMessage } from 'react-intl';
+import connectToStores from 'fluxible-addons-react/connectToStores';
+
+const TermsAndConditionsPage = ({ currentLanguage }, context) => {
+  const terms = context.config.termsAndConditions[currentLanguage];
+  return (
+    <div className="about-page fullscreen">
+      <div className="page-frame fullscreen momentum-scroll">
+        {terms.map(
+          (section, i) =>
+            (section.paragraphs && section.paragraphs.length) ||
+            section.link ? (
+              <div key={`about-section-${i}`}>
+                <h1 className="about-header">{section.header}</h1>
+                {section.paragraphs &&
+                  section.paragraphs.map((p, j) => (
+                    <p key={`about-section-${i}-p-${j}`}>{p}</p>
+                  ))}
+                {section.link && <Link to={section.link}>{section.link}</Link>}
+              </div>
+            ) : (
+              false
+            ),
+        )}
+        <Link to="/">
+          <div className="call-to-action-button">
+            <FormattedMessage
+              id="back-to-front-page"
+              defaultMessage="Back to front page"
+            />
+          </div>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+TermsAndConditionsPage.propTypes = {
+  currentLanguage: PropTypes.string.isRequired,
+};
+
+TermsAndConditionsPage.contextTypes = {
+  config: PropTypes.object.isRequired,
+};
+
+export default connectToStores(TermsAndConditionsPage, ['PreferencesStore'], context => ({
+  currentLanguage: context.getStore('PreferencesStore').getLanguage(),
+}));

--- a/app/routes.js
+++ b/app/routes.js
@@ -149,6 +149,28 @@ export default config => {
           ]).then(([title, content]) => cb(null, { title, content }));
         }}
       />
+      <Route
+        path="/terms-and-conditions"
+        getComponents={(location, cb) => {
+          Promise.all([
+            Promise.resolve(Title),
+            import(/* webpackChunkName: "terms-and-conditions" */ './component/TermsAndConditionsPage').then(
+              getDefault,
+            ),
+          ]).then(([title, content]) => cb(null, { title, content }));
+        }}
+      />
+      <Route
+        path="/privacy-policy"
+        getComponents={(location, cb) => {
+          Promise.all([
+            Promise.resolve(Title),
+            import(/* webpackChunkName: "privacy-policy" */ './component/PrivacyPolicyPage').then(
+              getDefault,
+            ),
+          ]).then(([title, content]) => cb(null, { title, content }));
+        }}
+      />
       {!config.URL.API_URL.includes('/api.') && (
         <Route
           path="/admin"


### PR DESCRIPTION
Add component pages for terms and conditions and privacy policy pages following the same pattern as the about page, with routes for each.