### PR TITLE
Toggle geojson layers

### DIFF
--- a/app/component/SelectMapLayersDialog.js
+++ b/app/component/SelectMapLayersDialog.js
@@ -73,7 +73,8 @@ class SelectMapLayersDialog extends React.Component {
     return (
       <React.Fragment>
         <div className="checkbox-grouping">
-          {isTransportModeEnabled(transportModes.bus) && (
+          {config.URL.STOP_MAP && 
+            isTransportModeEnabled(transportModes.bus) && (
             <React.Fragment>
               <Checkbox
                 checked={stop.bus}
@@ -93,7 +94,8 @@ class SelectMapLayersDialog extends React.Component {
               />
             </React.Fragment>
           )}
-          {isTransportModeEnabled(transportModes.tram) && (
+          {config.URL.STOP_MAP && 
+            isTransportModeEnabled(transportModes.tram) && (
             <Checkbox
               checked={stop.tram}
               defaultMessage="Tram stop"
@@ -101,7 +103,8 @@ class SelectMapLayersDialog extends React.Component {
               onChange={e => this.updateStopSetting({ tram: e.target.checked })}
             />
           )}
-          {isTransportModeEnabled(transportModes.rail) && (
+          {config.URL.STOP_MAP && 
+            isTransportModeEnabled(transportModes.rail) && (
             <Checkbox
               checked={terminal.rail}
               defaultMessage="Railway station"
@@ -111,7 +114,8 @@ class SelectMapLayersDialog extends React.Component {
               }
             />
           )}
-          {isTransportModeEnabled(transportModes.subway) && (
+          {config.URL.STOP_MAP && 
+            isTransportModeEnabled(transportModes.subway) && (
             <Checkbox
               checked={terminal.subway}
               defaultMessage="Subway station"
@@ -121,7 +125,8 @@ class SelectMapLayersDialog extends React.Component {
               }
             />
           )}
-          {isTransportModeEnabled(transportModes.ferry) && (
+          {config.URL.STOP_MAP && 
+            isTransportModeEnabled(transportModes.ferry) && (
             <Checkbox
               checked={stop.ferry}
               defaultMessage="Ferry"
@@ -131,7 +136,8 @@ class SelectMapLayersDialog extends React.Component {
               }
             />
           )}
-          {config.cityBike &&
+          {config.URL.CITYBIKE_MAP && 
+            config.cityBike &&
             config.cityBike.showCityBikes && (
               <Checkbox
                 checked={citybike}
@@ -142,7 +148,8 @@ class SelectMapLayersDialog extends React.Component {
                 }
               />
             )}
-          {config.parkAndRide &&
+          {config.URL.PARK_AND_RIDE_MAP && 
+            config.parkAndRide &&
             config.parkAndRide.showParkAndRide && (
               <Checkbox
                 checked={parkAndRide}

--- a/app/component/SelectMapLayersDialog.js
+++ b/app/component/SelectMapLayersDialog.js
@@ -70,10 +70,11 @@ class SelectMapLayersDialog extends React.Component {
     const isTransportModeEnabled = transportMode =>
       transportMode && transportMode.availableForSelection;
     const transportModes = config.transportModes || {};
+    const configUrls = config.URL || {};
     return (
       <React.Fragment>
         <div className="checkbox-grouping">
-          {config.URL.STOP_MAP && 
+          {configUrls.STOP_MAP && 
             isTransportModeEnabled(transportModes.bus) && (
             <React.Fragment>
               <Checkbox
@@ -94,7 +95,7 @@ class SelectMapLayersDialog extends React.Component {
               />
             </React.Fragment>
           )}
-          {config.URL.STOP_MAP && 
+          {configUrls.STOP_MAP && 
             isTransportModeEnabled(transportModes.tram) && (
             <Checkbox
               checked={stop.tram}
@@ -103,7 +104,7 @@ class SelectMapLayersDialog extends React.Component {
               onChange={e => this.updateStopSetting({ tram: e.target.checked })}
             />
           )}
-          {config.URL.STOP_MAP && 
+          {configUrls.STOP_MAP && 
             isTransportModeEnabled(transportModes.rail) && (
             <Checkbox
               checked={terminal.rail}
@@ -114,7 +115,7 @@ class SelectMapLayersDialog extends React.Component {
               }
             />
           )}
-          {config.URL.STOP_MAP && 
+          {configUrls.STOP_MAP && 
             isTransportModeEnabled(transportModes.subway) && (
             <Checkbox
               checked={terminal.subway}
@@ -125,7 +126,7 @@ class SelectMapLayersDialog extends React.Component {
               }
             />
           )}
-          {config.URL.STOP_MAP && 
+          {configUrls.STOP_MAP && 
             isTransportModeEnabled(transportModes.ferry) && (
             <Checkbox
               checked={stop.ferry}
@@ -136,7 +137,7 @@ class SelectMapLayersDialog extends React.Component {
               }
             />
           )}
-          {config.URL.CITYBIKE_MAP && 
+          {configUrls.CITYBIKE_MAP && 
             config.cityBike &&
             config.cityBike.showCityBikes && (
               <Checkbox
@@ -148,7 +149,7 @@ class SelectMapLayersDialog extends React.Component {
                 }
               />
             )}
-          {config.URL.PARK_AND_RIDE_MAP && 
+          {configUrls.PARK_AND_RIDE_MAP && 
             config.parkAndRide &&
             config.parkAndRide.showParkAndRide && (
               <Checkbox
@@ -233,6 +234,11 @@ const transportModeConfigShape = PropTypes.shape({
 });
 
 const mapLayersConfigShape = PropTypes.shape({
+  URL: PropTypes.shape({
+    STOP_MAP: PropTypes.string,
+    CITYBIKE_MAP: PropTypes.string,
+    PARK_AND_RIDE_MAP: PropTypes.string,
+  }),
   cityBike: PropTypes.shape({
     showCityBikes: PropTypes.bool,
   }),

--- a/app/component/map/GeoJSON.js
+++ b/app/component/map/GeoJSON.js
@@ -2,16 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import L from 'leaflet';
 import GeoJSONCluster from './GeoJSONCluster';
-import { isBrowser } from '../../util/browser';
 import GeoJsonPopup from './popups/GeoJsonPopup';
-
-let Geojson, MapTag;
-
-/* eslint-disable global-require */
-if (isBrowser) {
-  Geojson = require('react-leaflet/es/GeoJSON').default;
-}
-/* eslint-enable global-require */
 
 const GeoJsonIcon = L.Icon.extend({
   options: {
@@ -23,7 +14,7 @@ const GeoJsonIcon = L.Icon.extend({
 class GeoJSON extends React.Component {
   static propTypes = { 
     data: PropTypes.object.isRequired,
-    cluster: PropTypes.bool.isRequired
+    options: PropTypes.object.isRequired
   };
 
   static contextTypes = { config: PropTypes.object.isRequired };
@@ -52,12 +43,6 @@ class GeoJSON extends React.Component {
       }
     });
     this.icons = icons;
-
-    if(this.props.cluster) {
-      MapTag = GeoJSONCluster;
-    } else {
-      MapTag = Geojson;
-    }
   }
 
   pointToLayer = (feature, latlng) => {
@@ -135,7 +120,7 @@ class GeoJSON extends React.Component {
 
   render() {
     return (
-      <MapTag
+      <GeoJSONCluster
         data={this.props.data}
         style={this.styler}
         pointToLayer={this.pointToLayer}

--- a/app/component/map/GeoJSON.js
+++ b/app/component/map/GeoJSON.js
@@ -119,11 +119,15 @@ class GeoJSON extends React.Component {
   };
 
   render() {
+    const cluster = typeof this.props.options.cluster != "undefined" ? this.props.options.cluster : false;
+    const maxClusterZoom = cluster ? false : 1;
+
     return (
       <GeoJSONCluster
         data={this.props.data}
         style={this.styler}
         pointToLayer={this.pointToLayer}
+        maxClusterZoom={maxClusterZoom}
       />
     );
   }

--- a/app/component/map/GeoJSONCluster.js
+++ b/app/component/map/GeoJSONCluster.js
@@ -10,7 +10,7 @@ class GeoJSONCluster extends Path {
       showCoverageOnHover: false,
       zoomToBoundsOnClick: false,
       spiderfyOnMaxZoom: false,
-      disableClusteringAtZoom: 17
+      disableClusteringAtZoom: props.maxClusterZoom || 17
     });
     const geoJsonLayer = new LeafletGeoJSON(props.data, this.getOptions(props));
     clusterGroup.addLayer(geoJsonLayer);

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -68,6 +68,7 @@ class MapWithTrackingStateHandler extends React.Component {
     this.state = {
       geoJson: {},
       initialZoom: hasOriginorPosition ? FOCUS_ZOOM : DEFAULT_ZOOM,
+      currentZoom: hasOriginorPosition ? FOCUS_ZOOM : DEFAULT_ZOOM,
       mapTracking: props.origin.gps && props.position.hasLocation,
       focusOnOrigin: props.origin.ready,
       origin: props.origin,
@@ -131,6 +132,12 @@ class MapWithTrackingStateHandler extends React.Component {
       focusOnOrigin: false,
     });
   };
+
+  onZoom = (e) => {
+    this.setState({
+      currentZoom: e.target._zoom,
+    });
+  }
 
   usePosition(origin) {
     this.setState(prevState => ({
@@ -217,7 +224,7 @@ class MapWithTrackingStateHandler extends React.Component {
         origin={this.props.origin}
         leafletEvents={{
           onDragstart: this.disableMapTracking,
-          onZoomend: null, // this.disableMapTracking,
+          onZoomend: this.onZoom,
         }}
         disableMapTracking={this.disableMapTracking}
         {...rest}

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -79,11 +79,11 @@ class MapWithTrackingStateHandler extends React.Component {
     const { config, getGeoJsonData } = this.props;
     if (isBrowser && config.geoJson && Array.isArray(config.geoJson.layers)) {
       config.geoJson.layers.forEach(geoJsonLayer => {
-        const { url, name, metadata, cluster = false } = geoJsonLayer;
+        const { url, name, metadata, options = {} } = geoJsonLayer;
         getGeoJsonData(url, name, metadata).then(data => {
           const { geoJson } = this.state;
           geoJson[url] = data;
-          geoJson[url].cluster = cluster;
+          geoJson[url].options = options;
           if (!this.isCancelled) {
             this.setState({ geoJson });
           }
@@ -194,9 +194,14 @@ class MapWithTrackingStateHandler extends React.Component {
       Object.keys(geoJson)
         .filter(key => mapLayers.geoJson[key] !== false)
         .forEach(key => {
+          const options = geoJson[key].options;
           leafletObjs.push(
             <LazilyLoad modules={jsonModules} key={key}>
-              {({ GeoJSON }) => <GeoJSON data={geoJson[key].data} cluster={geoJson[key].cluster} />}
+              {
+                ({ GeoJSON }) => <GeoJSON
+                  data={geoJson[key].data}
+                  options={geoJson[key].options} />
+              }
             </LazilyLoad>,
           );
         });

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -202,6 +202,13 @@ class MapWithTrackingStateHandler extends React.Component {
         .filter(key => mapLayers.geoJson[key] !== false)
         .forEach(key => {
           const options = geoJson[key].options;
+
+          const minZoom = options.minZoom;
+          if(typeof minZoom != "undefined" && this.state.currentZoom < minZoom) return;
+
+          const maxZoom = options.maxZoom;
+          if(typeof maxZoom != "undefined" && this.state.currentZoom > maxZoom) return;
+
           leafletObjs.push(
             <LazilyLoad modules={jsonModules} key={key}>
               {

--- a/app/component/map/tile-layer/Stops.js
+++ b/app/component/map/tile-layer/Stops.js
@@ -50,6 +50,8 @@ class Stops {
   }
 
   getPromise() {
+    if (!this.config.URL.STOP_MAP) return null;
+    
     return fetch(
       `${this.config.URL.STOP_MAP}${this.tile.coords.z +
         (this.tile.props.zoomOffset || 0)}` +

--- a/app/component/selectmaplayersdialog.scss
+++ b/app/component/selectmaplayersdialog.scss
@@ -20,6 +20,13 @@
       position: absolute;
     }
   }
+  .checkbox-grouping:empty + .checkbox-grouping {
+    margin-top: 0;
+
+    &:before {
+      content: none;
+    }
+  }
 
   .option-checkbox-container + .option-checkbox-container {
     margin-top: 0.25em;

--- a/app/configurations/config.porto.js
+++ b/app/configurations/config.porto.js
@@ -27,8 +27,9 @@ export default configMerger(defaultConfig, {
     MAP: {
       default: `${MAP_URL}`,
     },
-    STOP_MAP: '',
-    CITYBIKE_MAP: '',
+    STOP_MAP: null,
+    CITYBIKE_MAP: null,
+    PARK_AND_RIDE_MAP: null,
     MQTT: '',
     ALERTS: process.env.ALERTS_URL || '',
     FONT:
@@ -184,20 +185,6 @@ export default configMerger(defaultConfig, {
     locationAware: true,
   },
 
-  // TODO: Switch off in autumn
-  cityBike: {
-    showCityBikes: true,
-    showStationId: true,
-
-    useUrl: {
-      en: 'https://www.hsl.fi/en/citybikes',
-    },
-
-    cityBikeMinZoom: 14,
-    cityBikeSmallIconZoom: 14,
-    // When should bikeshare availability be rendered in orange rather than green
-    fewAvailableCount: 3,
-  },
   // Lowest level for stops and terminals are rendered
   stopsMinZoom: 13,
   // Highest level when stops and terminals are still rendered as small markers

--- a/app/configurations/config.porto.js
+++ b/app/configurations/config.porto.js
@@ -803,7 +803,9 @@ export default configMerger(defaultConfig, {
           pt: 'POI',
         },
         url: '//desolate-falls-11658.herokuapp.com/pois',
-        cluster: true,
+        options: {
+          cluster: true
+        }
       },
       {
         name: {
@@ -813,7 +815,9 @@ export default configMerger(defaultConfig, {
           pt: 'Paragem de autocarro',
         },
         url: '//desolate-falls-11658.herokuapp.com/bus_stops',
-        cluster: true,
+        options: {
+          minZoom: 16,
+        }
       },
       {
         name: {
@@ -823,7 +827,9 @@ export default configMerger(defaultConfig, {
           pt: 'Metro',
         },
         url: '//desolate-falls-11658.herokuapp.com/metro_stops',
-        cluster: true,
+        options: {
+          minZoom: 16,
+        }
       },
     ],
   },

--- a/test/unit/component/SelectMapLayersDialog.test.js
+++ b/test/unit/component/SelectMapLayersDialog.test.js
@@ -37,6 +37,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         transportModes: {
           bus: {
             availableForSelection: true,
@@ -71,6 +76,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         transportModes: {
           bus: {
             availableForSelection: true,
@@ -105,6 +115,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         transportModes: {
           tram: {
             availableForSelection: true,
@@ -141,6 +156,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         transportModes: {
           rail: {
             availableForSelection: true,
@@ -178,6 +198,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         transportModes: {
           subway: {
             availableForSelection: true,
@@ -213,6 +238,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         transportModes: {
           ferry: {
             availableForSelection: true,
@@ -246,6 +276,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         cityBike: {
           showCityBikes: true,
         },
@@ -282,6 +317,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         parkAndRide: {
           showParkAndRide: true,
         },
@@ -316,6 +356,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         ticketSales: {
           showTicketSales: true,
         },
@@ -356,6 +401,11 @@ describe('<SelectMapLayersDialog />', () => {
     };
     const props = {
       config: {
+        URL: {
+          STOP_MAP: ' ',
+          CITYBIKE_MAP: ' ',
+          PARK_AND_RIDE_MAP: ' ',
+        },
         geoJson: {
           layers: [
             {


### PR DESCRIPTION
Adds minZoom and maxZoom to geoJSON layers
Hides layers that are not in use from layer selector

Toggling layers and clustering live is not very stable, so instead of toggling between GeoJSON and GeoJSONCluster we are always using the cluster and we are toggling the disableClusteringAtZoom between 1 and 17 (resulting in the same thing for the user, but with better performance and less bugs)